### PR TITLE
Add hot reloading capability

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "license": "MIT",
   "main": "index.js",
   "scripts": {
-    "build": "webpack",
+    "build": "NODE_ENV=production webpack",
     "deploy": "surge -p public -d feather.surge.sh",
     "lint": "standard",
     "start": "webpack-dev-server",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "style-loader": "^0.13.0",
     "stylus-loader": "^1.4.2",
     "surge": "^0.17.3",
+    "ud": "^3.0.0",
     "url-loader": "^0.5.7",
     "vdom-as-json": "^1.0.8",
     "vdom-serialized-patch": "^1.0.2",

--- a/src/ud.production.js
+++ b/src/ud.production.js
@@ -1,0 +1,2 @@
+export const defobj = (module, obj) => obj
+export const defn = (module, fn) => fn

--- a/src/views/home.js
+++ b/src/views/home.js
@@ -1,6 +1,6 @@
 export default ({count}) => (
   <div>
-    <p>This app weighs about 8.5kb</p>
+    <p>This app weighs about 15kb</p>
     <button data-click={{type: 'decrement'}}> - </button>
     <span> {count} </span>
     <button data-click={{type: 'increment'}}> + </button>

--- a/src/views/home.js
+++ b/src/views/home.js
@@ -1,6 +1,6 @@
 export default ({count}) => (
   <div>
-    <p>This app weighs about 15kb</p>
+    <p>This app weighs about 8.5kb</p>
     <button data-click={{type: 'decrement'}}> - </button>
     <span> {count} </span>
     <button data-click={{type: 'increment'}}> + </button>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,10 @@
 require('babel-register')
+var webpack = require('webpack')
 var getConfig = require('hjs-webpack')
 var toHtml = require('vdom-to-html')
 var app = require('./src/views/app').default
 
-module.exports = getConfig({
+var config = getConfig({
   in: 'src/main.js',
   out: 'public',
   clearBeforeBuild: true,
@@ -18,3 +19,11 @@ module.exports = getConfig({
     }
   }
 })
+
+if (process.env.NODE_ENV === 'production') {
+  config.plugins.push(
+    new webpack.NormalModuleReplacementPlugin(/^ud$/, __dirname + '/src/ud.production.js')
+  )
+}
+
+module.exports = config


### PR DESCRIPTION
Here it is! It definitely makes development easier.

But... I'm actually a bit dissatisfied with something I just noticed. The `ud` module that I'm using to make the hot reloading a lot easier is still included even when it's a production build. This makes the build swell up to ~15kb gzipped. Oof. I'm PRing this first revision from Juicy, but I don't think this is ready to be merged as-is. I want to see if there's a way to make it only include `ud` in development, or at least just a shim of it in production.
